### PR TITLE
Fix PHPStan complaining about accessing protected `currentGroup` property

### DIFF
--- a/src/Multiplier.php
+++ b/src/Multiplier.php
@@ -418,7 +418,7 @@ class Multiplier extends Container
 	protected function createContainer(): Container
 	{
 		$control = new Container();
-		$control->currentGroup = $this->currentGroup;
+		$control->setCurrentGroup($this->currentGroup);
 		$this->fillContainer($control);
 
 		return $control;


### PR DESCRIPTION
PHPStan 2.1.8 started to complain about `property.protected`:

    Access to protected property Nette\Forms\Container::$currentGroup.

See https://github.com/phpstan/phpstan/issues/13123

Fortunately, Nette provides a public method we can use instead.
